### PR TITLE
Add basic navigation

### DIFF
--- a/frontend/centero/lib/age.dart
+++ b/frontend/centero/lib/age.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'role_selection.dart';
+
+class AgePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+          child: Text('Go to role selection page'),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => RoleSelectionPage()),
+            );
+          },
+        ),
+    );
+  }
+}

--- a/frontend/centero/lib/age.dart
+++ b/frontend/centero/lib/age.dart
@@ -4,8 +4,12 @@ import 'role_selection.dart';
 class AgePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: ElevatedButton(
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Age Page'), 
+      ),
+      body: Center(
+        child: ElevatedButton(
           child: Text('Go to role selection page'),
           onPressed: () {
             Navigator.push(
@@ -14,6 +18,7 @@ class AgePage extends StatelessWidget {
             );
           },
         ),
+      ),
     );
   }
 }

--- a/frontend/centero/lib/call_interface.dart
+++ b/frontend/centero/lib/call_interface.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
-import 'face_id_notice.dart';
+import 'end_contact.dart';
 
-class RoleSelectionPage extends StatelessWidget {
+class CallInterfacePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Role Selection Page'), 
+        title: Text('Call Interface Page'), 
       ),
       body: Center(
         child: ElevatedButton(
-          child: Text('Go to face id notice page'),
+          child: Text('Go to end contact page'),
           onPressed: () {
             Navigator.push(
               context,
-              MaterialPageRoute(builder: (context) => FaceIDNoticePage()),
+              MaterialPageRoute(builder: (context) => EndContactPage()),
             );
           },
         ),

--- a/frontend/centero/lib/end_contact.dart
+++ b/frontend/centero/lib/end_contact.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
-import 'face_id_notice.dart';
+import 'home.dart';
 
-class RoleSelectionPage extends StatelessWidget {
+class EndContactPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Role Selection Page'), 
+        title: Text('End Contact Page'), 
       ),
       body: Center(
         child: ElevatedButton(
-          child: Text('Go to face id notice page'),
+          child: Text('Return to home page'),
           onPressed: () {
             Navigator.push(
               context,
-              MaterialPageRoute(builder: (context) => FaceIDNoticePage()),
+              MaterialPageRoute(builder: (context) => HomePage()),
             );
           },
         ),

--- a/frontend/centero/lib/face_id_notice.dart
+++ b/frontend/centero/lib/face_id_notice.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
-import 'face_id_notice.dart';
+import 'face_id_scan.dart';
 
-class RoleSelectionPage extends StatelessWidget {
+class FaceIDNoticePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Role Selection Page'), 
+        title: Text('Face ID Notice Page'), 
       ),
       body: Center(
         child: ElevatedButton(
-          child: Text('Go to face id notice page'),
+          child: Text('Go to face id scan page'),
           onPressed: () {
             Navigator.push(
               context,
-              MaterialPageRoute(builder: (context) => FaceIDNoticePage()),
+              MaterialPageRoute(builder: (context) => FaceIDScanPage()),
             );
           },
         ),

--- a/frontend/centero/lib/face_id_scan.dart
+++ b/frontend/centero/lib/face_id_scan.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
-import 'face_id_notice.dart';
+import 'resident_call_options.dart';
 
-class RoleSelectionPage extends StatelessWidget {
+class FaceIDScanPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Role Selection Page'), 
+        title: Text('Face ID Scan Page'), 
       ),
       body: Center(
         child: ElevatedButton(
-          child: Text('Go to face id notice page'),
+          child: Text('Go to resident call options page'),
           onPressed: () {
             Navigator.push(
               context,
-              MaterialPageRoute(builder: (context) => FaceIDNoticePage()),
+              MaterialPageRoute(builder: (context) => ResidentCallOptionsPage()),
             );
           },
         ),

--- a/frontend/centero/lib/home.dart
+++ b/frontend/centero/lib/home.dart
@@ -33,6 +33,9 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: Text('Home Page'), 
+      ),
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min, // center the buttons vertically

--- a/frontend/centero/lib/home.dart
+++ b/frontend/centero/lib/home.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'age.dart';
+
+class HomePage extends StatefulWidget {
+  @override
+  _HomePageState createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  // This is the asynchronous method that fetches data from your server
+  Future<void> fetchHelloWorld() async {
+    final uri = Uri.parse('http://127.0.0.1:5001/centerobackend-14820/us-central1/helloWorld');
+    try {
+      final response = await http.get(uri);
+      if (response.statusCode == 200) {
+        // If server returns an OK response, show the response body in a Snackbar
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Response: ${response.body}')),
+        );
+      } else {
+        // If the server did not return a 200 OK response,
+        // then throw an exception.
+        throw Exception('Failed to load data from the server');
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min, // center the buttons vertically
+          children: [
+            ElevatedButton(
+              onPressed: fetchHelloWorld,
+              child: Text('Fetch Hello World'),
+            ),
+            SizedBox(height: 20), // Spacing between buttons
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => AgePage()),
+                );
+              },
+              child: Text('Go to age page'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/centero/lib/main.dart
+++ b/frontend/centero/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:firebase_core/firebase_core.dart';
-import 'package:http/http.dart' as http;
+import 'home.dart';
 
 void main() {
   runApp(const MyApp());
@@ -13,7 +12,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Centero',
       theme: ThemeData(
         // This is the theme of your application.
         //
@@ -33,115 +32,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  Future<void> fetchHelloWorld() async {
-    final uri = Uri.parse('http://127.0.0.1:5001/centerobackend-14820/us-central1/helloWorld');
-    try {
-      final res = await http.get(uri);
-      if (res.statusCode == 200) {
-        // if the server returns a 200 OK response, then parse the JSON
-        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Response: ${res.body}')));
-      } else {
-        // if the server did not return a 200 OK response, then throw an exception
-        throw Exception('Failed to load data from the server');
-      }
-    } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Error: $e')));
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-            ElevatedButton(
-              onPressed: fetchHelloWorld,
-              child: Text('Fetch Hello World'),
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: HomePage(),
     );
   }
 }

--- a/frontend/centero/lib/resident_call_options.dart
+++ b/frontend/centero/lib/resident_call_options.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
-import 'face_id_notice.dart';
+import 'call_interface.dart';
 
-class RoleSelectionPage extends StatelessWidget {
+class ResidentCallOptionsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Role Selection Page'), 
+        title: Text('Resident Call Options Page'), 
       ),
       body: Center(
         child: ElevatedButton(
-          child: Text('Go to face id notice page'),
+          child: Text('Go to call interface page'),
           onPressed: () {
             Navigator.push(
               context,
-              MaterialPageRoute(builder: (context) => FaceIDNoticePage()),
+              MaterialPageRoute(builder: (context) => CallInterfacePage()),
             );
           },
         ),

--- a/frontend/centero/lib/role_selection.dart
+++ b/frontend/centero/lib/role_selection.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'home.dart';
+
+class RoleSelectionPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ElevatedButton(
+          child: Text('Return to home page'),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => HomePage()),
+            );
+          },
+        ),
+    );
+  }
+}


### PR DESCRIPTION
# Add Basic Navigation to Frontend

## Changes
- Add home, age, role selection, face ID notice, face ID scan, resident call options, call interface, and end contact pages
- Add buttons to navigate from one page to another in a linear fashion as listed using the Navigator widget

## Testing
- The home page should appear upon starting the program
- Clicking on the "Go to..." buttons should bring the user to the correct page, verifying with the app bar title on the top left corner of the page. Make sure the order of the pages you visit match the order I listed them in the bullet point under "Changes"
- The last page should return back to the home page
- Clicking the back arrow should bring you back to the previous page
- The fetch hello world endpoint on the home page returns the correct response

## Images
N/A
