### PR TITLE
Navigate to next page from face id notice page based on last page

### DIFF
--- a/frontend/centero/lib/pages/faceid_notice.dart
+++ b/frontend/centero/lib/pages/faceid_notice.dart
@@ -1,4 +1,5 @@
 import 'package:centero/pages/face_scan_fail.dart';
+import 'package:centero/pages/face_scan_nonresident.dart';
 import 'package:centero/widgets/button_secondary.dart';
 import 'package:centero/widgets/page_frame2.dart';
 import 'package:flutter/material.dart';
@@ -10,10 +11,14 @@ import 'face_scan.dart';
 import 'welcome_home.dart';
 
 class FaceIDNotice extends StatelessWidget {
-  //Stack
+  final String? previousPage; 
+
+  // Constructor
+  const FaceIDNotice({Key? key, this.previousPage}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    //Widgets
+    // Widgets
     Widget faceScanner() {
       return SvgPicture.asset(
         'assets/face_scan_reticle.svg',
@@ -57,10 +62,16 @@ class FaceIDNotice extends StatelessWidget {
     Widget btnProceed() {
       return ButtonPrimary(
         onPressed: () {
-          Navigator.push(
+          if (previousPage == 'role selection') {
+            Navigator.push(
             context,
-            MaterialPageRoute(builder: (context) => FaceScan()),
-          );
+            MaterialPageRoute(builder: (context) => FaceScan()));
+          }
+          else {
+            Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => PageFaceScanNonresident()));
+          }
         },
         child: Text(
           'Get Started',

--- a/frontend/centero/lib/pages/feedback_bad_end.dart
+++ b/frontend/centero/lib/pages/feedback_bad_end.dart
@@ -1,8 +1,6 @@
-import 'package:centero/pages/call_supervisor_loading.dart';
 import 'package:centero/widgets/page_frame.dart';
 import 'package:centero/widgets/button_primary.dart';
 import 'package:centero/widgets/button_danger.dart';
-import 'package:centero/widgets/button_secondary.dart';
 import 'package:flutter/material.dart';
 import 'welcome_home.dart';
 

--- a/frontend/centero/lib/pages/info_non_resident_role_selection.dart
+++ b/frontend/centero/lib/pages/info_non_resident_role_selection.dart
@@ -1,4 +1,3 @@
-import 'package:centero/pages/face_scan_nonresident.dart';
 import 'package:centero/widgets/page_frame2.dart';
 import 'package:centero/widgets/button_primary.dart';
 import 'package:flutter/material.dart';
@@ -9,7 +8,7 @@ class PageInfoNonResidentRoleSelection extends StatelessWidget {
   void nonresidentFaceScan(BuildContext context) {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (context) => PageFaceScanNonresident()),
+      MaterialPageRoute(builder: (context) => FaceIDNotice()),
     );
   }
 

--- a/frontend/centero/lib/pages/info_role_selection.dart
+++ b/frontend/centero/lib/pages/info_role_selection.dart
@@ -9,7 +9,7 @@ class PageInfoRoleSelection extends StatelessWidget {
   void residentFaceScan(BuildContext context) {
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (context) => FaceIDNotice()),
+      MaterialPageRoute(builder: (context) => FaceIDNotice(previousPage: 'role selection',)),
     );
   }
 


### PR DESCRIPTION
# Navigate to next page from face id notice page based on last page

## Changes
- Changed FaceIDNotice page to accept a parameter that determines which page to proceed to

## Testing
Verified the resident and nonresident flows are correct when it comes to the face id notice page

## Images
N/A
