### PR TITLE
Change call buttons to icons

### DIFF
--- a/frontend/centero/lib/pages/call_regular.dart
+++ b/frontend/centero/lib/pages/call_regular.dart
@@ -3,7 +3,6 @@ import 'package:centero/widgets/name_header.dart';
 import 'package:centero/widgets/page_frame_rcall.dart';
 import 'package:centero/widgets/button_end_call.dart';
 import 'package:centero/widgets/button_mute.dart';
-import 'feedback_select.dart';
 import 'package:flutter/material.dart';
 
 class PageCallRegular extends StatelessWidget {
@@ -19,17 +18,13 @@ class PageCallRegular extends StatelessWidget {
     Widget muteButton() {
       return ButtonMute(
         onPressed: () {}, 
-        child: Text('Mute', 
-          style: TextStyle(fontSize: 80, fontFamily: 'Josefin'), 
-          textAlign: TextAlign.center));
+        child: Icon(Icons.mic_rounded, size: 190));
     }
 
     Widget endCallButton() {
       return ButtonEndCall(
         onPressed: () {nextScreen(context);},
-        child: Text('End Call', 
-          style: TextStyle(fontSize: 80, fontFamily: 'Josefin'), 
-          textAlign: TextAlign.center));
+        child: Icon(Icons.call_end_rounded, size: 190));
     }
 
     Widget nameHeader() {

--- a/frontend/centero/lib/pages/call_supervisor.dart
+++ b/frontend/centero/lib/pages/call_supervisor.dart
@@ -18,17 +18,13 @@ class PageCallSupervisor extends StatelessWidget {
     Widget muteButton() {
       return ButtonMute(
         onPressed: () {}, 
-        child: Text('Mute', 
-          style: TextStyle(fontSize: 80, fontFamily: 'Josefin'), 
-          textAlign: TextAlign.center));
+        child: Icon(Icons.mic_rounded, size: 190));
     }
 
     Widget endCallButton() {
       return ButtonEndCall(
         onPressed: () {nextScreen(context);},
-        child: Text('End Call', 
-          style: TextStyle(fontSize: 80, fontFamily: 'Josefin'), 
-          textAlign: TextAlign.center));
+        child: Icon(Icons.call_end_rounded, size: 190));
     }
 
     Widget escalatedCallHeader() {


### PR DESCRIPTION
# Change call buttons to icons

## Changes
- Replace text in call buttons with icons

## Testing
Chose icons from material library that closely resemble those in figma

## Images
![image](https://github.com/UCI-191-VirtuRealty-Visionaries/Centero/assets/90677583/3744c352-bed7-482f-b029-029133088c26)
